### PR TITLE
Fix: ls throws IOError on empty directories

### DIFF
--- a/src/System/HDFS.hs
+++ b/src/System/HDFS.hs
@@ -191,8 +191,7 @@ ls :: FileSystem -> Path -> IO [FileInfo]
 ls (FileSystem fs) p =
   withCString p $ \path   ->
   alloca        $ \numptr -> do
-    cinfo <- --throwErrnoIfNull "ls" $
-               c_hdfs_list_directory fs path numptr
+    cinfo <- c_hdfs_list_directory fs path numptr
     num   <- peek numptr
     info  <- peekArray (fromIntegral num) cinfo >>= mapM mkFileInfo
     c_hdfs_free_file_info cinfo num


### PR DESCRIPTION
Null is a valid return value for empty directories.

See also: https://github.com/avaranovich/libhdfs/issues/1